### PR TITLE
Added extra labels to load balancer logs exported to loki

### DIFF
--- a/tools/lambda-promtail/lambda-promtail/s3.go
+++ b/tools/lambda-promtail/lambda-promtail/s3.go
@@ -36,7 +36,7 @@ var (
 	// the indexes of the fields in the log that we want to create labels for
 	typeIndex              = loadBalancerLogLineRegex.SubexpIndex("type")
 	targetPortIndex        = loadBalancerLogLineRegex.SubexpIndex("target_port")
-	requestUrlIndex        = loadBalancerLogLineRegex.SubexpIndex("request_url")
+	requestUrlIndex        = loadBalancerLogLineRegex.SubexpIndex("request_url") // we create a label for the endpoint of the url, not the full url
 	elbStatusCodeIndex     = loadBalancerLogLineRegex.SubexpIndex("elb_status_code")
 	targetStatusCodeIndex  = loadBalancerLogLineRegex.SubexpIndex("target_status_code")
 	lambdaErrorReasonIndex = loadBalancerLogLineRegex.SubexpIndex("lambda_error_reason")

--- a/tools/lambda-promtail/lambda-promtail/s3.go
+++ b/tools/lambda-promtail/lambda-promtail/s3.go
@@ -35,7 +35,6 @@ var (
 
 	// the indexes of the fields in the log that we want to create labels for
 	typeIndex              = loadBalancerLogLineRegex.SubexpIndex("type")
-	targetPortIndex        = loadBalancerLogLineRegex.SubexpIndex("target_port")
 	requestUrlIndex        = loadBalancerLogLineRegex.SubexpIndex("request_url") // we create a label for the endpoint of the url, not the full url
 	elbStatusCodeIndex     = loadBalancerLogLineRegex.SubexpIndex("elb_status_code")
 	targetStatusCodeIndex  = loadBalancerLogLineRegex.SubexpIndex("target_status_code")
@@ -48,7 +47,7 @@ var (
 	requestUrlEndpointRegex = regexp.MustCompile(`([^0-9/]*$)`)
 
 	// don't push load balancer logs with traffic to these endpoints to loki
-	skipEndpoints = map[string]struct{}{"external-health-check": {}, "healthz": {}, "readiness": {}, "healthy": {}}
+	skipEndpoints = map[string]struct{}{"external-health-check": {}, "healthz": {}, "readiness": {}, "healthy": {}, "metrics": {}, "readyz": {}}
 )
 
 func getS3Object(ctx context.Context, labels map[string]string) (io.ReadCloser, error) {
@@ -112,7 +111,6 @@ func parseS3Log(ctx context.Context, b *batch, labels map[string]string, obj io.
 		if _, skip := skipEndpoints[targetEndpoint]; !skip {
 			logLineLabelSet := model.LabelSet{
 				model.LabelName("lb_type"):                model.LabelValue(logLineMatch[typeIndex]),
-				model.LabelName("lb_target_port"):         model.LabelValue(logLineMatch[targetPortIndex]),
 				model.LabelName("lb_target_endpoint"):     model.LabelValue(targetEndpoint),
 				model.LabelName("lb_elb_status_code"):     model.LabelValue(logLineMatch[elbStatusCodeIndex]),
 				model.LabelName("lb_target_status_code"):  model.LabelValue(logLineMatch[targetStatusCodeIndex]),


### PR DESCRIPTION
Added new labels to load balancer logs. Full list of entries in the logs that could be made into labels found here under `Access log entries / Syntax`: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html

I just chose the ones that I thought made the most sense, but we can update this list. Current new labels:
```
type
targetPort
targetEndpoint
elbStatusCode
targetStatusCode
lambdaErrorReason
```
The docs link above goes into what each of these fields means.

I've also excluded logs with these targetEndpoint values from being pushed to loki:
```
external-health-check
healthz
readiness
healthy
```
Tested this on dev and it's working.