### PR TITLE
Add S3 access log downsampling

### DIFF
--- a/tools/lambda-promtail/Dockerfile
+++ b/tools/lambda-promtail/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1-alpine3.14 AS build-image
+FROM golang:1.18-alpine3.15 AS build-image
 
 COPY tools/lambda-promtail /src/lambda-promtail
 WORKDIR /src/lambda-promtail
@@ -12,7 +12,7 @@ RUN go mod download
 RUN go build -o ./main -tags lambda.norpc -ldflags="-s -w" lambda-promtail/*.go
 
 
-FROM alpine:3.15.4
+FROM alpine:3.15
 
 WORKDIR /app
 

--- a/tools/lambda-promtail/go.mod
+++ b/tools/lambda-promtail/go.mod
@@ -1,6 +1,6 @@
 module main
 
-go 1.17
+go 1.18
 
 require (
 	github.com/aws/aws-lambda-go v1.26.0

--- a/tools/lambda-promtail/lambda-promtail/collections.go
+++ b/tools/lambda-promtail/lambda-promtail/collections.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"encoding/json"
+	"net/netip"
+	"regexp"
+	"strings"
+)
+
+// CommaSeparatedStringSet represents a set of strings that unmarshals from a comma-separated string in JSON.
+type CommaSeparatedStringSet map[string]struct{}
+
+func (set *CommaSeparatedStringSet) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	fragments := strings.Split(s, ",")
+	m := make(CommaSeparatedStringSet, len(fragments))
+	for _, f := range fragments {
+		m[f] = struct{}{}
+	}
+	*set = m
+	return nil
+}
+
+// Contains returns true if set contains s.
+func (set CommaSeparatedStringSet) Contains(s string) bool {
+	_, ok := set[s]
+	return ok
+}
+
+// CommaSeparatedCIDRSet represents a set of IP prefixes (a.k.a. CIDR blocks) that unmarshals from a comma-separated string in JSON.
+type CommaSeparatedCIDRSet map[netip.Prefix]struct{}
+
+func (set *CommaSeparatedCIDRSet) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	fragments := strings.Split(s, ",")
+	m := make(CommaSeparatedCIDRSet, len(fragments))
+	for _, f := range fragments {
+		m[netip.MustParsePrefix(f)] = struct{}{}
+	}
+	*set = m
+	return nil
+}
+
+// Contains returns true if set contains s.
+func (set CommaSeparatedCIDRSet) Contains(p netip.Prefix) bool {
+	_, ok := set[p]
+	return ok
+}
+
+// Match returns true if ip matches any of the prefixes in this set.
+func (set CommaSeparatedCIDRSet) Match(ip netip.Addr) bool {
+	for prefix, _ := range set {
+		if prefix.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// CommaSeparatedHostnameSet represents a set of hostnames that unmarshals from a comma-separated string in JSON.
+// Hostnames can include wildcards e.g. "*.example.org".
+type CommaSeparatedHostnameSet struct {
+	pattern string
+	r       *regexp.Regexp
+}
+
+func (set *CommaSeparatedHostnameSet) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	fragments := strings.Split(s, ",")
+	for i, f := range fragments {
+		f = strings.ReplaceAll(f, "*", "@") // Replace wildcards with a temp symbol that isn't a regex control character.
+		f = regexp.QuoteMeta(f)             // Quote the dots in the hostname.
+		f = strings.ReplaceAll(f, "@", ".*")
+		fragments[i] = f
+	}
+	pattern := "^(" + strings.Join(fragments, "|") + ")$"
+	r, err := regexp.Compile(pattern)
+	if err != nil {
+		return err
+	}
+	*set = CommaSeparatedHostnameSet{
+		pattern: pattern,
+		r:       r,
+	}
+	return nil
+}
+
+// Match returns true if matches any of the hostnames in this set, including by wildcard.
+func (set *CommaSeparatedHostnameSet) Match(hostname string) bool {
+	if set == nil {
+		return false
+	}
+	return set.r.MatchString(hostname)
+}
+
+func (set *CommaSeparatedHostnameSet) IsZero() bool {
+	if set == nil {
+		return true
+	}
+	return set.pattern == "^()$"
+}

--- a/tools/lambda-promtail/lambda-promtail/main.go
+++ b/tools/lambda-promtail/lambda-promtail/main.go
@@ -33,6 +33,7 @@ var (
 	batchSize                          int
 	s3Clients                          map[string]*s3.Client
 	extraLabels                        model.LabelSet
+	s3SampleFilters                    []*S3SamplingConfig
 )
 
 func setupArguments() {
@@ -76,6 +77,13 @@ func setupArguments() {
 	}
 
 	s3Clients = make(map[string]*s3.Client)
+
+	s3Sampling := os.Getenv("SAMPLE_S3")
+	if s3Sampling != "" {
+		if err := json.Unmarshal([]byte(s3Sampling), &s3SampleFilters); err != nil {
+			panic(err)
+		}
+	}
 }
 
 func parseExtraLabels(extraLabelsRaw string) (model.LabelSet, error) {

--- a/tools/lambda-promtail/lambda-promtail/s3_test.go
+++ b/tools/lambda-promtail/lambda-promtail/s3_test.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestS3SamplingConfig_Match(t *testing.T) {
+	type args struct {
+		accountID string
+		logLine   string
+		confJSON  string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "health",
+			args: args{
+				accountID: "123456789012",
+				logLine:   `https 2022-05-18T02:35:01.039648Z app/k8s-albdefault-d03a586d74/0b1519348a786e51 65.175.50.10:35362 10.14.102.123:80 0.000 0.030 0.000 200 200 6514 167 "GET https://onprem-qa.cortex.svc.us-monitoring1.logs.mintel.cloud:443/external-health-check HTTP/1.1" "Prometheus/2.23.0" ECDHE-RSA-AES128-GCM-SHA256 TLSv1.2 arn:aws:elasticloadbalancing:us-east-2:529633446764:targetgroup/k8s-ingressc-haproxyi-294703d4c5/7a4aad31d5cea679 "Root=1-62845b55-735a492258a7d74058509db2" "onprem-qa.cortex.svc.us-monitoring1.logs.mintel.cloud" "arn:aws:acm:us-east-2:529633446764:certificate/974741ab-49bd-46ab-81b6-beeea653799a" 1 2022-05-18T02:35:01.009000Z "forward" "-" "-" "10.14.102.123:80" "200" "-" "-"`,
+				confJSON: `
+					{
+						"keep": 0.1,
+						"path": "/(external-health-check|healthz|healthy|readiness|readyz|metrics)$"
+					}
+				`,
+			},
+			want: true,
+		},
+		{
+			name: "not-health",
+			args: args{
+				accountID: "123456789012",
+				logLine:   `https 2022-05-18T02:35:00.892913Z app/k8s-albdefault-d03a586d74/0b1519348a786e51 5.148.102.70:57512 10.14.102.123:80 0.000 0.004 0.000 401 401 777 316 "POST https://onprem-qa.loki.svc.us-monitoring1.logs.mintel.cloud:443/loki/api/v1/push HTTP/1.1" "promtail/2.0.0" ECDHE-RSA-AES128-GCM-SHA256 TLSv1.2 arn:aws:elasticloadbalancing:us-east-2:529633446764:targetgroup/k8s-ingressc-haproxyi-294703d4c5/7a4aad31d5cea679 "Root=1-62845b54-03322dfe71483c2658d8e32a" "onprem-qa.loki.svc.us-monitoring1.logs.mintel.cloud" "arn:aws:acm:us-east-2:529633446764:certificate/d04ec6bf-79af-45c9-bd52-c4352efe0e56" 1 2022-05-18T02:35:00.888000Z "forward" "-" "-" "10.14.102.123:80" "401" "-" "-"`,
+				confJSON: `
+					{
+						"keep": 0.1,
+						"path": "/(external-health-check|healthz|healthy|readiness|readyz|metrics)$"
+					}
+				`,
+			},
+			want: false,
+		},
+		{
+			name: "health-substring",
+			args: args{
+				accountID: "123456789012",
+				logLine:   `https 2022-05-18T02:35:00.892913Z app/k8s-albdefault-d03a586d74/0b1519348a786e51 5.148.102.70:57512 10.14.102.123:80 0.000 0.004 0.000 401 401 777 316 "POST https://onprem-qa.loki.svc.us-monitoring1.logs.mintel.cloud:443/example/healthz HTTP/1.1" "promtail/2.0.0" ECDHE-RSA-AES128-GCM-SHA256 TLSv1.2 arn:aws:elasticloadbalancing:us-east-2:529633446764:targetgroup/k8s-ingressc-haproxyi-294703d4c5/7a4aad31d5cea679 "Root=1-62845b54-03322dfe71483c2658d8e32a" "onprem-qa.loki.svc.us-monitoring1.logs.mintel.cloud" "arn:aws:acm:us-east-2:529633446764:certificate/d04ec6bf-79af-45c9-bd52-c4352efe0e56" 1 2022-05-18T02:35:00.888000Z "forward" "-" "-" "10.14.102.123:80" "401" "-" "-"`,
+				confJSON: `
+					{
+						"keep": 0.1,
+						"path": "/(external-health-check|healthz|healthy|readiness|readyz|metrics)$"
+					}
+				`,
+			},
+			want: true,
+		},
+		{
+			name: "loki",
+			args: args{
+				accountID: "123456789012",
+				logLine:   `https 2022-05-18T02:35:00.892913Z app/k8s-albdefault-d03a586d74/0b1519348a786e51 5.148.102.70:57512 10.14.102.123:80 0.000 0.004 0.000 401 401 777 316 "POST https://onprem-qa.loki.svc.us-monitoring1.logs.mintel.cloud:443/loki/api/v1/push HTTP/1.1" "promtail/2.0.0" ECDHE-RSA-AES128-GCM-SHA256 TLSv1.2 arn:aws:elasticloadbalancing:us-east-2:529633446764:targetgroup/k8s-ingressc-haproxyi-294703d4c5/7a4aad31d5cea679 "Root=1-62845b54-03322dfe71483c2658d8e32a" "onprem-qa.loki.svc.us-monitoring1.logs.mintel.cloud" "arn:aws:acm:us-east-2:529633446764:certificate/d04ec6bf-79af-45c9-bd52-c4352efe0e56" 1 2022-05-18T02:35:00.888000Z "forward" "-" "-" "10.14.102.123:80" "401" "-" "-"`,
+				confJSON: `
+					{
+						"keep": 0.1,
+						"host": "*.loki.*",
+						"path": "^/loki/api/v1/push"
+					}
+				`,
+			},
+			want: true,
+		},
+		{
+			name: "cortex",
+			args: args{
+				accountID: "123456789012",
+				logLine:   `https 2022-05-18T02:35:01.039648Z app/k8s-albdefault-d03a586d74/0b1519348a786e51 65.175.50.10:35362 10.14.102.123:80 0.000 0.030 0.000 200 200 6514 167 "POST https://onprem-qa.cortex.svc.us-monitoring1.logs.mintel.cloud:443/api/v1/push HTTP/1.1" "Prometheus/2.23.0" ECDHE-RSA-AES128-GCM-SHA256 TLSv1.2 arn:aws:elasticloadbalancing:us-east-2:529633446764:targetgroup/k8s-ingressc-haproxyi-294703d4c5/7a4aad31d5cea679 "Root=1-62845b55-735a492258a7d74058509db2" "onprem-qa.cortex.svc.us-monitoring1.logs.mintel.cloud" "arn:aws:acm:us-east-2:529633446764:certificate/974741ab-49bd-46ab-81b6-beeea653799a" 1 2022-05-18T02:35:01.009000Z "forward" "-" "-" "10.14.102.123:80" "200" "-" "-"`,
+				confJSON: `
+					{
+						"keep": 0.1,
+						"host": "*.cortex.*",
+						"path": "^(/api/v1/push|/api/prom/push|/prometheus/api/v1/write)"
+					}
+				`,
+			},
+			want: true,
+		},
+		{
+			name: "ip",
+			args: args{
+				accountID: "123456789012",
+				logLine:   `https 2022-05-18T02:35:01.039648Z app/k8s-albdefault-d03a586d74/0b1519348a786e51 65.175.50.10:35362 10.14.102.123:80 0.000 0.030 0.000 200 200 6514 167 "GET https://onprem-qa.cortex.svc.us-monitoring1.logs.mintel.cloud:443/external-health-check HTTP/1.1" "Prometheus/2.23.0" ECDHE-RSA-AES128-GCM-SHA256 TLSv1.2 arn:aws:elasticloadbalancing:us-east-2:529633446764:targetgroup/k8s-ingressc-haproxyi-294703d4c5/7a4aad31d5cea679 "Root=1-62845b55-735a492258a7d74058509db2" "onprem-qa.cortex.svc.us-monitoring1.logs.mintel.cloud" "arn:aws:acm:us-east-2:529633446764:certificate/974741ab-49bd-46ab-81b6-beeea653799a" 1 2022-05-18T02:35:01.009000Z "forward" "-" "-" "10.14.102.123:80" "200" "-" "-"`,
+				confJSON: `
+					{
+						"keep": 0.1,
+						"ip": "65.175.0.0/16"
+					}
+				`,
+			},
+			want: true,
+		},
+		{
+			name: "not-ip",
+			args: args{
+				accountID: "123456789012",
+				logLine:   `https 2022-05-18T02:35:01.039648Z app/k8s-albdefault-d03a586d74/0b1519348a786e51 65.175.50.10:35362 10.14.102.123:80 0.000 0.030 0.000 200 200 6514 167 "GET https://onprem-qa.cortex.svc.us-monitoring1.logs.mintel.cloud:443/external-health-check HTTP/1.1" "Prometheus/2.23.0" ECDHE-RSA-AES128-GCM-SHA256 TLSv1.2 arn:aws:elasticloadbalancing:us-east-2:529633446764:targetgroup/k8s-ingressc-haproxyi-294703d4c5/7a4aad31d5cea679 "Root=1-62845b55-735a492258a7d74058509db2" "onprem-qa.cortex.svc.us-monitoring1.logs.mintel.cloud" "arn:aws:acm:us-east-2:529633446764:certificate/974741ab-49bd-46ab-81b6-beeea653799a" 1 2022-05-18T02:35:01.009000Z "forward" "-" "-" "10.14.102.123:80" "200" "-" "-"`,
+				confJSON: `
+					{
+						"keep": 0.1,
+						"ip": "10.0.0.0/16"
+					}
+				`,
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var conf *S3SamplingConfig
+			err := json.Unmarshal([]byte(strings.TrimSpace(tt.args.confJSON)), &conf)
+			if err != nil {
+				t.Fatal(err)
+			}
+			logLineMatch := loadBalancerLogLineRegex.FindStringSubmatch(tt.args.logLine)
+			if len(logLineMatch) == 0 {
+				t.Fatal("log line does not match regexp")
+			}
+			got := conf.Match(tt.args.accountID, logLineMatch)
+			if tt.want {
+				require.True(t, got)
+			} else {
+				require.False(t, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds a new env var `SAMPLE_S3` which takes a JSON-encoded string to
configure a list of downsampling filters on load balancer access logs.
Each filter matches of zero or more criteria, and if a log line matches
then it will be dropped with a random probability.