### PR TITLE
Add sampling config for CloudWatch logs

### DIFF
--- a/tools/lambda-promtail/lambda-promtail/cw.go
+++ b/tools/lambda-promtail/lambda-promtail/cw.go
@@ -3,12 +3,74 @@ package main
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"time"
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/prometheus/common/model"
 )
+
+// CloudWatchSamplingConfig represents some pattern of CloudWatch logs that
+// should be dropped probabilistically.
+type CloudWatchSamplingConfig struct {
+	AccountIDs CommaSeparatedStringSet `json:"account"` // List of AWS account IDs to match on e.g. "123456789012,2345678901234".
+
+	// A regexp that will be matched against the name of the log group.
+	LogGroup *RegexpString `json:"log_group"`
+
+	// A regexp that will be matched against the name of the log stream.
+	LogStream *RegexpString `json:"log_stream"`
+
+	// A regexp that will be matched against each log line.
+	LogLine *RegexpString `json:"log"`
+
+	// A probability between 0 and 1.
+	// If a log line matches the filters above, keep that log line with this probability.
+	KeepRate float64 `json:"keep"`
+}
+
+// MatchStream returns true if a CloudWatch logs events matches this sampling filter.
+func (conf *CloudWatchSamplingConfig) MatchStream(accountID, logGroup, logStream string) bool {
+	if len(conf.AccountIDs) > 0 {
+		if !conf.AccountIDs.Contains(accountID) {
+			return false
+		}
+	}
+	if !conf.LogGroup.IsZero() {
+		if !conf.LogGroup.MatchString(logGroup) {
+			return false
+		}
+	}
+	if !conf.LogStream.IsZero() {
+		if !conf.LogStream.MatchString(logStream) {
+			return false
+		}
+	}
+	return true
+}
+
+// MatchLine returns true if an individual CloudWatch log line matches the LogLine regexp.
+func (conf *CloudWatchSamplingConfig) MatchLine(logLine string) bool {
+	if !conf.LogLine.IsZero() {
+		if !conf.LogLine.MatchString(logLine) {
+			return false
+		}
+	}
+	return true
+}
+
+// Keep randomly returns true or false at a rate depending on conf.KeepRate.
+// A KeepRate of 0.1 will return true on 10% of calls to Keep.
+func (conf *CloudWatchSamplingConfig) Keep() bool {
+	if conf.KeepRate == 0 {
+		return false
+	}
+	if conf.KeepRate == 1 {
+		return true
+	}
+	return rand.Float64() <= conf.KeepRate
+}
 
 func parseCWEvent(ctx context.Context, b *batch, ev *events.CloudwatchLogsEvent) error {
 	data, err := ev.AWSLogs.Parse()
@@ -26,9 +88,21 @@ func parseCWEvent(ctx context.Context, b *batch, ev *events.CloudwatchLogsEvent)
 		labels[model.LabelName("__aws_cloudwatch_log_stream")] = model.LabelValue(data.LogStream)
 	}
 
+	var matchingSampleConf *CloudWatchSamplingConfig
+	for _, c := range cloudWatchSampleFilters {
+		if c.MatchStream(data.Owner, data.LogGroup, data.LogStream) {
+			matchingSampleConf = c
+			break
+		}
+	}
+
 	labels = applyExtraLabels(labels)
 
 	for _, event := range data.LogEvents {
+		if matchingSampleConf != nil && matchingSampleConf.MatchLine(event.Message) && !matchingSampleConf.Keep() {
+			continue
+		}
+
 		timestamp := time.UnixMilli(event.Timestamp)
 
 		b.add(ctx, entry{labels, logproto.Entry{

--- a/tools/lambda-promtail/lambda-promtail/main.go
+++ b/tools/lambda-promtail/lambda-promtail/main.go
@@ -33,6 +33,7 @@ var (
 	batchSize                          int
 	s3Clients                          map[string]*s3.Client
 	extraLabels                        model.LabelSet
+	cloudWatchSampleFilters            []*CloudWatchSamplingConfig
 	s3SampleFilters                    []*S3SamplingConfig
 )
 
@@ -77,6 +78,13 @@ func setupArguments() {
 	}
 
 	s3Clients = make(map[string]*s3.Client)
+
+	cloudWatchSampling := os.Getenv("SAMPLE_CLOUDWATCH")
+	if cloudWatchSampling != "" {
+		if err := json.Unmarshal([]byte(cloudWatchSampling), &cloudWatchSampleFilters); err != nil {
+			panic(err)
+		}
+	}
 
 	s3Sampling := os.Getenv("SAMPLE_S3")
 	if s3Sampling != "" {

--- a/tools/lambda-promtail/lambda-promtail/s3.go
+++ b/tools/lambda-promtail/lambda-promtail/s3.go
@@ -62,8 +62,7 @@ type S3SamplingConfig struct {
 	Hosts             *CommaSeparatedHostnameSet `json:"host"`   // List of hostnames matched against the hostname of the request. Can include wildcards e.g. `*.example.org`.
 
 	// A regexp that will be matched against the path of the request.
-	Path       string `json:"path"`
-	pathRegexp *regexp.Regexp
+	Path *RegexpString `json:"path"`
 
 	// A probability between 0 and 1.
 	// If a log line matches the filters above, keep that log line with this probability.
@@ -115,11 +114,8 @@ func (conf *S3SamplingConfig) Match(accountID string, logLineMatch []string) boo
 			return false
 		}
 	}
-	if conf.Path != "" {
-		if conf.pathRegexp == nil {
-			conf.pathRegexp = regexp.MustCompile(conf.Path)
-		}
-		if !conf.pathRegexp.MatchString(u.Path) {
+	if !conf.Path.IsZero() {
+		if !conf.Path.MatchString(u.Path) {
 			return false
 		}
 	}

--- a/tools/lambda-promtail/lambda-promtail/types.go
+++ b/tools/lambda-promtail/lambda-promtail/types.go
@@ -108,3 +108,43 @@ func (set *CommaSeparatedHostnameSet) IsZero() bool {
 	}
 	return set.pattern == "^()$"
 }
+
+// RegexpString represents a JSON-encoded regexp pattern that can be unmarshaled.
+type RegexpString struct {
+	*regexp.Regexp
+	Value string
+}
+
+func (rs *RegexpString) UnmarshalJSON(data []byte) error {
+	var s string
+	err := json.Unmarshal(data, &s)
+	if err != nil {
+		return err
+	}
+	var p *regexp.Regexp
+	if s != "" {
+		p, err = regexp.Compile(s)
+		if err != nil {
+			return err
+		}
+	}
+	*rs = RegexpString{
+		Value:  s,
+		Regexp: p,
+	}
+	return nil
+}
+
+func (rs *RegexpString) String() string {
+	return rs.Value
+}
+
+func (rs *RegexpString) IsZero() bool {
+	if rs == nil {
+		return true
+	}
+	if rs.Value == "" || rs.Regexp == nil {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
Add the ability to downsample CloudWatch logs that match regex patterns.

Also compile regexps at Lambda start time.